### PR TITLE
Break up adaptation into multiple solvers, show output Circuit Json SVG, fix applying layout to circuit json to include proper net labels

### DIFF
--- a/lib/builder/CircuitBuilder.ts
+++ b/lib/builder/CircuitBuilder.ts
@@ -29,11 +29,23 @@ export class CircuitBuilder {
 
   private autoLabelCounter = 1
 
+  public name: string
+
+  constructor(
+    opts: {
+      name?: string
+    } = {},
+  ) {
+    this.name = opts.name ?? "Circuit"
+  }
+
   /* ------------------------------------------------------------------ *
    * Deep-clone without JSON.stringify (avoids cyclic-structure error)  *
    * ------------------------------------------------------------------ */
   clone(): CircuitBuilder {
-    const clone = new CircuitBuilder()
+    const clone = new CircuitBuilder({
+      name: this.name,
+    })
 
     /* 1.  basic scalar state */
     clone.autoLabelCounter = this.autoLabelCounter

--- a/lib/builder/circuit.ts
+++ b/lib/builder/circuit.ts
@@ -1,6 +1,10 @@
 import { CircuitBuilder } from "./CircuitBuilder"
 
-export function circuit(): CircuitBuilder {
-  return new CircuitBuilder()
+export function circuit(opts: {
+  name?: string
+} = {}): CircuitBuilder {
+  return new CircuitBuilder({
+    name: opts.name,
+  })
 }
 export default circuit

--- a/lib/circuit-json/applyCircuitLayoutToCircuitJson.ts
+++ b/lib/circuit-json/applyCircuitLayoutToCircuitJson.ts
@@ -115,7 +115,7 @@ export const applyCircuitLayoutToCircuitJson = (
   for (const layoutLabel of layout.netLabels) {
     const netIndex = layoutNorm.transform.netIdToNetIndex[layoutLabel.labelId]
     const compositeNetId =
-      netIndexToCompositeNetId.get(netIndex)! ??
+      netIndexToCompositeNetId.get(netIndex!)! ??
       "ERROR: did not find netId using net index"
     const newLabel: SchematicNetLabel = {
       type: "schematic_net_label",

--- a/lib/solvers/AdaptTemplateToNetlistSolver.ts
+++ b/lib/solvers/AdaptTemplateToNetlistSolver.ts
@@ -1,0 +1,93 @@
+import type { InputNetlist } from "lib/input-types"
+import { BaseSolver } from "./BaseSolver"
+import type { CircuitBuilder } from "lib/builder"
+import type { EditOperation } from "lib/adapt/EditOperation"
+import { adaptTemplateToTarget } from "lib/adapt/adaptTemplateToTarget"
+import { getReadableNetlist } from "lib/netlist/getReadableNetlist"
+
+/**
+ * Adapts a template to match a target netlist by applying edit operations
+ */
+export class AdaptTemplateToNetlistSolver extends BaseSolver {
+  inputTemplate: CircuitBuilder
+  targetNetlist: InputNetlist
+
+  outputAdaptedTemplate: CircuitBuilder | null = null
+  outputAppliedOperations: EditOperation[] = []
+
+  constructor(opts: {
+    inputTemplate: CircuitBuilder
+    targetNetlist: InputNetlist
+  }) {
+    super()
+    this.inputTemplate = opts.inputTemplate
+    this.targetNetlist = opts.targetNetlist
+  }
+
+  getConstructorParams() {
+    return {
+      inputTemplate: this.inputTemplate,
+      targetNetlist: this.targetNetlist,
+    }
+  }
+
+  getStatsSummary() {
+    return `${this.outputAppliedOperations.length} operations applied`
+  }
+
+  _step() {
+    // Clone the template to avoid mutating the original
+    const templateClone = this.inputTemplate.clone()
+
+    // Apply the adaptation
+    const result = adaptTemplateToTarget({
+      template: templateClone,
+      target: this.targetNetlist,
+    })
+
+    this.outputAdaptedTemplate = templateClone
+    this.outputAppliedOperations = result.appliedOperations
+
+    // Store stats
+    this.stats = {
+      operationCount: this.outputAppliedOperations.length,
+      templateBoxCount: templateClone.getNetlist().boxes?.length || 0,
+      targetBoxCount: this.targetNetlist.boxes?.length || 0,
+    }
+
+    this.solved = true
+  }
+
+  visualize() {
+    return [
+      {
+        title: "inputTemplate",
+        ascii: this.inputTemplate.toString(),
+      },
+      {
+        title: "targetNetlist",
+        ascii: getReadableNetlist(this.targetNetlist),
+      },
+      {
+        title: "adaptedTemplate",
+        ascii: this.outputAdaptedTemplate?.toString() || "No adapted template",
+      },
+      {
+        title: "appliedOperations",
+        table: this.outputAppliedOperations.map((op, index) => ({
+          operation_index: index,
+          type: op.type,
+          details: op,
+        })),
+      },
+      {
+        title: "inputTemplateReadableNetlist",
+        ascii: this.inputTemplate.getReadableNetlist(),
+      },
+      {
+        title: "adaptedTemplateReadableNetlist",
+        ascii: this.outputAdaptedTemplate?.getReadableNetlist() || "No adapted template",
+      },
+    ]
+  }
+}

--- a/lib/solvers/MatchNetlistToTemplateSolver.ts
+++ b/lib/solvers/MatchNetlistToTemplateSolver.ts
@@ -4,6 +4,7 @@ import type { CircuitBuilder } from "lib/builder"
 import { TEMPLATE_FNS } from "templates/index"
 import { ScoreNetlistTemplatePairSolver } from "./ScoreNetlistTemplatePairSolver"
 import type { MatchingIssue } from "lib/matching/types"
+import { getReadableNetlist } from "lib/netlist/getReadableNetlist"
 
 /**
  * Find the best match template for a netlist by scoring all templates
@@ -100,5 +101,28 @@ export class MatchNetlistToTemplateSolver extends BaseSolver {
     }
 
     this.solved = true
+  }
+
+  visualize() {
+    return [
+      {
+        title: "inputNetlist",
+        ascii: getReadableNetlist(this.inputNetlist),
+      },
+      {
+        title: "bestMatchTemplate",
+        ascii: this.outputBestMatchTemplate?.toString() || "No suitable match found",
+      },
+      {
+        title: "templateScores",
+        table: this.templateMatchResults.map((result, index) => ({
+          template_index: index,
+          template_name: result.template.name || `Template ${index}`,
+          similarity_distance: result.similarityDistance,
+          issue_count: result.issues.length,
+          is_best_match: result.template === this.outputBestMatchTemplate,
+        })),
+      },
+    ]
   }
 }

--- a/templates/template1.ts
+++ b/templates/template1.ts
@@ -57,7 +57,9 @@ import { circuit } from "lib/builder"
  * ```
  */
 export default () => {
-  const C = circuit()
+  const C = circuit({
+    name: "Template 1",
+  })
   const U1 = C.chip().leftpins(2).rightpins(2)
   U1.pin(1).line(-8, 0).line(0, -2).passive().line(0, -2).label()
   U1.pin(2).line(-3, 0).line(0, -2).label()

--- a/templates/template2.ts
+++ b/templates/template2.ts
@@ -107,7 +107,9 @@ import { circuit } from "lib/builder"
  * ```
  */
 export default () => {
-  const C = circuit()
+  const C = circuit({
+    name: "Template 2",
+  })
   const U1 = C.chip().rightpins(7)
 
   U1.pin(7).line(2, 0).line(0, 2).label()

--- a/templates/template3.ts
+++ b/templates/template3.ts
@@ -81,7 +81,9 @@ import { circuit } from "lib/builder"
  * ```
  */
 export default () => {
-  const C = circuit()
+  const C = circuit({
+    name: "Template 3",
+  })
   const U1 = C.chip().rightpins(3)
 
   U1.pin(3).line(4, 0).mark("m0").line(3, 0).mark("m1").line(0, 1).label()

--- a/templates/template4.ts
+++ b/templates/template4.ts
@@ -69,7 +69,9 @@ import { circuit } from "lib/builder"
  * ```
  */
 export default () => {
-  const C = circuit()
+  const C = circuit({
+    name: "Template 4",
+  })
   const U1 = C.chip().rightpins(3)
 
   U1.pin(3).line(4, 0).mark("m1").line(0, 2).label()

--- a/templates/template5.ts
+++ b/templates/template5.ts
@@ -28,7 +28,9 @@ import { circuit } from "lib/builder"
  * ```
  */
 export default () => {
-  const C = circuit()
+  const C = circuit({
+    name: "Template 5",
+  })
   const U1 = C.chip().leftpins(2).rightpins(2).at(0, 0)
   const U2 = C.chip().leftpins(1).rightpins(1).at(10, 0.2)
 

--- a/templates/template6.ts
+++ b/templates/template6.ts
@@ -89,7 +89,9 @@ import { circuit } from "lib/builder"
  * ```
  */
 export default () => {
-  const C = circuit()
+  const C = circuit({
+    name: "Template 6",
+  })
 
   const U2 = C.chip("U2").leftpins(3).rightpins(3).at(0, 0)
 

--- a/website/components/PipelineDebugger.tsx
+++ b/website/components/PipelineDebugger.tsx
@@ -1,10 +1,11 @@
-import type { SchematicLayoutPipelineSolver } from "lib/solvers/SchematicLayoutPipelineSolver"
+import { SchematicLayoutPipelineSolver } from "lib/solvers/SchematicLayoutPipelineSolver"
 import type { BaseSolver } from "lib/solvers/BaseSolver"
 import { PipelineDebuggerSidebar } from "./PipelineDebuggerSidebar"
 import { PipelineDebuggerSolverVisualizations } from "./PipelineDebuggerSolverVisualizations"
 import { useState, useEffect } from "react"
 import { testTscircuitCodeForLayout } from "tests/tscircuit/testTscircuitCodeForLayout"
 import { convertCircuitJsonToSchematicSvg } from "circuit-to-svg"
+import { convertCircuitJsonToInputNetlist } from "lib/circuit-json/convertCircuitJsonToInputNetlist"
 
 /**
  * This component debugs the Schematic Layout Pipeline.
@@ -33,15 +34,6 @@ export const PipelineDebugger = (props: {
 
       try {
         const results = await testTscircuitCodeForLayout(props.tscircuitCode)
-
-        // Extract the solver from the execution
-        // We need to re-run the solver to get the full pipeline state
-        const { SchematicLayoutPipelineSolver } = await import(
-          "lib/solvers/SchematicLayoutPipelineSolver"
-        )
-        const { convertCircuitJsonToInputNetlist } = await import(
-          "lib/circuit-json/convertCircuitJsonToInputNetlist"
-        )
 
         setOriginalSvgString(
           convertCircuitJsonToSchematicSvg(results.originalCircuitJson, {


### PR DESCRIPTION
- **template names, adapt matched templates independently inside a separate solver**
- **show "after layout" in overview**
- **fix application of adaptation to circuit json**
