### PR TITLE
Add power/ground net properties

### DIFF
--- a/lib/builder/CircuitBuilder/CircuitBuilder.ts
+++ b/lib/builder/CircuitBuilder/CircuitBuilder.ts
@@ -202,7 +202,13 @@ export class CircuitBuilder {
     }
     // c. For every netLabel
     for (const label of this.netLabels) {
-      nb.addNet({ netId: label.netId })
+      const upper = label.netId.toUpperCase()
+      const isGround = upper === "GND" || upper === "AGND"
+      const isPositivePower = /^V/i.test(label.netId)
+      const net: Net = { netId: label.netId }
+      if (isGround) net.isGround = true
+      if (isPositivePower) net.isPositivePower = true
+      nb.addNet(net)
       nb.connect(label.fromRef, {
         netId: label.netId,
         netLabelId: label.netLabelId,

--- a/lib/circuit-json/convertCircuitJsonToInputNetlist.ts
+++ b/lib/circuit-json/convertCircuitJsonToInputNetlist.ts
@@ -136,12 +136,17 @@ export const convertCircuitJsonToInputNetlist = (
       }
     }
 
+    const upper = netId.toUpperCase()
+    const isGround = upper === "GND" || upper === "AGND"
+    const isPositivePower = /^V/i.test(netId)
+
     connection.connectedPorts.push({
       netId,
     })
-    nets.push({
-      netId,
-    })
+    const net: Net = { netId }
+    if (isGround) net.isGround = true
+    if (isPositivePower) net.isPositivePower = true
+    nets.push(net)
   }
 
   return {

--- a/lib/input-types.ts
+++ b/lib/input-types.ts
@@ -18,6 +18,10 @@ export interface Connection {
 
 export interface Net {
   netId: string
+  /** True if this net is a ground connection (e.g. GND, AGND) */
+  isGround?: boolean
+  /** True if this net is a positive power rail (e.g. VCC, VDD, V5) */
+  isPositivePower?: boolean
 }
 
 export interface InputNetlist {

--- a/lib/netlist/NetlistBuilder.ts
+++ b/lib/netlist/NetlistBuilder.ts
@@ -25,7 +25,11 @@ export class NetlistBuilder {
   }
 
   addNet(net: Net): void {
-    if (!this.netlist.nets.find((n) => n.netId === net.netId)) {
+    const existing = this.netlist.nets.find((n) => n.netId === net.netId)
+    if (existing) {
+      if (net.isGround) existing.isGround = true
+      if (net.isPositivePower) existing.isPositivePower = true
+    } else {
       this.netlist.nets.push(net)
     }
   }

--- a/lib/netlist/convertNormalizedNetlistToInputNetlist.ts
+++ b/lib/netlist/convertNormalizedNetlistToInputNetlist.ts
@@ -14,6 +14,8 @@ export const convertNormalizedNetlistToInputNetlist = (
 
   const nets: InputNetlist["nets"] = normalizedNetlist.nets.map((n) => ({
     netId: `net${n.netIndex}`,
+    isGround: n.isGround,
+    isPositivePower: n.isPositivePower,
   }))
 
   const connections: InputNetlist["connections"] =

--- a/lib/scoring/normalizeNetlist.ts
+++ b/lib/scoring/normalizeNetlist.ts
@@ -66,9 +66,14 @@ export const normalizeNetlist = (
   })
 
   const normalizedNets: NormalizedNetlist["nets"] = finalSortedNetIds.map(
-    (nid) => ({
-      netIndex: transform.netIdToNetIndex[nid]!,
-    }),
+    (nid) => {
+      const original = netlist.nets.find((n) => n.netId === nid)!
+      return {
+        netIndex: transform.netIdToNetIndex[nid]!,
+        isGround: original.isGround,
+        isPositivePower: original.isPositivePower,
+      }
+    },
   )
 
   /* ---------- connections (unchanged) ---------- */

--- a/lib/scoring/types.ts
+++ b/lib/scoring/types.ts
@@ -12,6 +12,10 @@ export interface NormalizedNetlistConnection {
 }
 export interface NormalizedNetlistNet {
   netIndex: number
+  /** Whether the original net was a ground connection */
+  isGround?: boolean
+  /** Whether the original net was a positive power rail */
+  isPositivePower?: boolean
 }
 export interface NormalizedNetlist {
   boxes: Array<NormalizedNetlistBox>

--- a/tests/areNetlistsCompatible3.test.ts
+++ b/tests/areNetlistsCompatible3.test.ts
@@ -162,12 +162,18 @@ test("areNetlistsCompatible with template4", () => {
       ],
       "nets": [
         {
+          "isGround": undefined,
+          "isPositivePower": undefined,
           "netIndex": 0,
         },
         {
+          "isGround": undefined,
+          "isPositivePower": undefined,
           "netIndex": 1,
         },
         {
+          "isGround": undefined,
+          "isPositivePower": undefined,
           "netIndex": 2,
         },
       ],
@@ -244,15 +250,23 @@ test("areNetlistsCompatible with template4", () => {
       ],
       "nets": [
         {
+          "isGround": undefined,
+          "isPositivePower": undefined,
           "netIndex": 0,
         },
         {
+          "isGround": undefined,
+          "isPositivePower": undefined,
           "netIndex": 1,
         },
         {
+          "isGround": undefined,
+          "isPositivePower": undefined,
           "netIndex": 2,
         },
         {
+          "isGround": undefined,
+          "isPositivePower": undefined,
           "netIndex": 3,
         },
       ],

--- a/tests/netProperties.test.ts
+++ b/tests/netProperties.test.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "bun:test"
+import { circuit } from "lib/builder"
+import { normalizeNetlist } from "lib/scoring/normalizeNetlist"
+
+test("net properties propagate", () => {
+  const C = circuit()
+  const U1 = C.chip().leftpins(2)
+  U1.pin(1).line(-1, 0).label("GND")
+  U1.pin(2).line(1, 0).label("VCC")
+
+  const netlist = C.getNetlist()
+  const gnd = netlist.nets.find((n) => n.netId === "GND")!
+  const vcc = netlist.nets.find((n) => n.netId === "VCC")!
+
+  expect(gnd.isGround).toBe(true)
+  expect(gnd.isPositivePower).toBeFalsy()
+  expect(vcc.isPositivePower).toBe(true)
+  expect(vcc.isGround).toBeFalsy()
+
+  const { normalizedNetlist, transform } = normalizeNetlist(netlist)
+  const gndIndex = transform.netIdToNetIndex["GND"]!
+  const vccIndex = transform.netIdToNetIndex["VCC"]!
+
+  expect(normalizedNetlist.nets[gndIndex]!.isGround).toBe(true)
+  expect(normalizedNetlist.nets[vccIndex]!.isPositivePower).toBe(true)
+})

--- a/tests/normalizeNetlist1.test.ts
+++ b/tests/normalizeNetlist1.test.ts
@@ -128,9 +128,13 @@ test("normalizeNetlist should correctly normalize a simple netlist", () => {
       ],
       "nets": [
         {
+          "isGround": undefined,
+          "isPositivePower": undefined,
           "netIndex": 0,
         },
         {
+          "isGround": undefined,
+          "isPositivePower": undefined,
           "netIndex": 1,
         },
       ],
@@ -250,6 +254,8 @@ test("normalizeNetlist with different ID order but same structure", () => {
       ],
       "nets": [
         {
+          "isGround": undefined,
+          "isPositivePower": undefined,
           "netIndex": 0,
         },
       ],

--- a/tests/normalizeNetlist2.test.ts
+++ b/tests/normalizeNetlist2.test.ts
@@ -221,6 +221,8 @@ test("normalizeNetlist should be invariant to box and connection order", () => {
       ],
       "nets": [
         {
+          "isGround": undefined,
+          "isPositivePower": undefined,
           "netIndex": 0,
         },
       ],

--- a/tests/repros/repro2-netlist-shared-gnd.test.ts
+++ b/tests/repros/repro2-netlist-shared-gnd.test.ts
@@ -77,9 +77,11 @@ test("repro2-netlist-shared-gnd", () => {
       ],
       "nets": [
         {
+          "isPositivePower": true,
           "netId": "VCC",
         },
         {
+          "isGround": true,
           "netId": "GND",
         },
       ],

--- a/tests/repros/repro3-top-pin-passive.test.ts
+++ b/tests/repros/repro3-top-pin-passive.test.ts
@@ -102,9 +102,11 @@ test("repro3-top-pin-passive", () => {
       ],
       "nets": [
         {
+          "isPositivePower": true,
           "netId": "VCC",
         },
         {
+          "isGround": true,
           "netId": "GND",
         },
       ],

--- a/tests/tscircuit/tscircuit1.test.ts
+++ b/tests/tscircuit/tscircuit1.test.ts
@@ -410,6 +410,8 @@ export default () => (
         ],
         "nets": [
           {
+            "isGround": undefined,
+            "isPositivePower": undefined,
             "netIndex": 0,
           },
         ],
@@ -490,9 +492,13 @@ export default () => (
         ],
         "nets": [
           {
+            "isGround": undefined,
+            "isPositivePower": undefined,
             "netIndex": 0,
           },
           {
+            "isGround": undefined,
+            "isPositivePower": undefined,
             "netIndex": 1,
           },
         ],

--- a/tests/tscircuit/tscircuit2.test.ts
+++ b/tests/tscircuit/tscircuit2.test.ts
@@ -328,21 +328,33 @@ export default () => (
         ],
         "nets": [
           {
+            "isGround": undefined,
+            "isPositivePower": undefined,
             "netIndex": 0,
           },
           {
+            "isGround": undefined,
+            "isPositivePower": undefined,
             "netIndex": 1,
           },
           {
+            "isGround": undefined,
+            "isPositivePower": undefined,
             "netIndex": 2,
           },
           {
+            "isGround": undefined,
+            "isPositivePower": undefined,
             "netIndex": 3,
           },
           {
+            "isGround": undefined,
+            "isPositivePower": undefined,
             "netIndex": 4,
           },
           {
+            "isGround": undefined,
+            "isPositivePower": undefined,
             "netIndex": 5,
           },
         ],
@@ -522,18 +534,28 @@ export default () => (
         ],
         "nets": [
           {
+            "isGround": undefined,
+            "isPositivePower": undefined,
             "netIndex": 0,
           },
           {
+            "isGround": true,
+            "isPositivePower": undefined,
             "netIndex": 1,
           },
           {
+            "isGround": undefined,
+            "isPositivePower": undefined,
             "netIndex": 2,
           },
           {
+            "isGround": undefined,
+            "isPositivePower": true,
             "netIndex": 3,
           },
           {
+            "isGround": undefined,
+            "isPositivePower": undefined,
             "netIndex": 4,
           },
         ],

--- a/tests/tscircuit/tscircuit6.test.ts
+++ b/tests/tscircuit/tscircuit6.test.ts
@@ -718,6 +718,7 @@ export default () => (
           "netId": "connectivity_net22",
         },
         {
+          "isGround": true,
           "netId": "GND",
         },
       ],
@@ -948,18 +949,28 @@ export default () => (
         ],
         "nets": [
           {
+            "isGround": true,
+            "isPositivePower": undefined,
             "netIndex": 0,
           },
           {
+            "isGround": undefined,
+            "isPositivePower": undefined,
             "netIndex": 1,
           },
           {
+            "isGround": undefined,
+            "isPositivePower": undefined,
             "netIndex": 2,
           },
           {
+            "isGround": undefined,
+            "isPositivePower": undefined,
             "netIndex": 3,
           },
           {
+            "isGround": undefined,
+            "isPositivePower": undefined,
             "netIndex": 4,
           },
         ],


### PR DESCRIPTION
## Summary
- add `isGround` and `isPositivePower` fields to `Net` and carry them through normalization
- update `NetlistBuilder` and `CircuitBuilder` to set these flags when labels such as `VCC` or `GND` are used
- handle these flags when converting netlists
- adjust tests and add new `netProperties` test

## Testing
- `bun run format`
- `bun test --no-color`


------
https://chatgpt.com/codex/tasks/task_b_6841392fa6cc832e8d6e22c68a062abd