### PR TITLE
Fix net label orientation in layouts

### DIFF
--- a/lib/builder/CircuitBuilder/getCircuitLayoutJson.ts
+++ b/lib/builder/CircuitBuilder/getCircuitLayoutJson.ts
@@ -58,12 +58,33 @@ export const getCircuitLayoutJson = (
 
   // Convert net labels
   for (const label of circuitBuilder.netLabels) {
+    // Determine orientation from the line segment that connects to this label
+    let anchor = label.anchorSide
+    const connectingLine = circuitBuilder.lines.find(
+      (l) =>
+        (l.end.ref as PortReference).netLabelId === label.netLabelId ||
+        (l.start.ref as PortReference).netLabelId === label.netLabelId,
+    )
+    if (connectingLine) {
+      let dx: number, dy: number
+      if (
+        (connectingLine.end.ref as PortReference).netLabelId ===
+        label.netLabelId
+      ) {
+        dx = connectingLine.end.x - connectingLine.start.x
+        dy = connectingLine.end.y - connectingLine.start.y
+      } else {
+        dx = connectingLine.start.x - connectingLine.end.x
+        dy = connectingLine.start.y - connectingLine.end.y
+      }
+      anchor = dx > 0 ? "left" : dx < 0 ? "right" : dy > 0 ? "bottom" : "top"
+    }
     netLabels.push({
       netLabelId: label.netLabelId,
       netId: label.netId,
       x: label.x,
       y: label.y,
-      anchorPosition: label.anchorSide,
+      anchorPosition: anchor,
     })
   }
 

--- a/tests/getCircuitLayoutJson/labelOrientation.test.ts
+++ b/tests/getCircuitLayoutJson/labelOrientation.test.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "bun:test"
+import { circuit } from "../../lib/builder"
+
+// orientation should be computed from the final line to the label
+
+// Build circuit with a label initially placed after a horizontal move
+// Then mutate the line so the final segment to the label is vertical
+
+test("label orientation follows final line direction", () => {
+  const C = circuit({ name: "Test" })
+  const U = C.chip("U1").leftpins(1)
+
+  // Draw a horizontal line then add a label
+  const pb = U.pin(1)
+  pb.line(1, 0).label("NET")
+
+  // Mutate the line so it ends vertically at the label
+  const line = C.lines[0]!
+  line.end.x = line.start.x
+  line.end.y = line.start.y + 1
+
+  // Update label position to match
+  const label = C.netLabels[0]!
+  label.x = line.end.x
+  label.y = line.end.y
+
+  const layout = C.getLayoutJson()
+  expect(layout.netLabels[0]!.anchorPosition).toBe("bottom")
+})


### PR DESCRIPTION
## Summary
- detect net label orientation from the line segment attached to the label
- test that orientation uses the final line direction

## Testing
- `bun test tests/getCircuitLayoutJson/labelOrientation.test.ts`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_684519ce5834832e9144f66837351aee